### PR TITLE
Upgrade point from 1 to 3

### DIFF
--- a/WpfApp_Test/MainWindow.xaml
+++ b/WpfApp_Test/MainWindow.xaml
@@ -14,21 +14,44 @@
 
         <Border Background="White" Padding="10">
             <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
 
-                <StackPanel Orientation="Horizontal" Grid.Column="0">
+                <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="0">
                     <ComboBox Width="200" Margin="0,0,10,0"/>
                     <TextBlock Text="ID" VerticalAlignment="Center" Margin="0,0,5,0"/>
                     <TextBox x:Name="ID_txt" Width="50" IsReadOnly="True" Background="WhiteSmoke"/>
                 </StackPanel>
+                
+                <StackPanel Orientation="Horizontal" 
+                            Grid.Column="0" 
+                            Grid.Row="1"
+                            Margin="0,20,0,0">
+                    <TextBlock Text="Název pravidla" Margin="0,0,10,0"/>
+                    <TextBox x:Name="NazevPravidla" IsReadOnly="True" Background="WhiteSmoke" FontSize="14" Width="190"/>
+                </StackPanel>
 
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="1">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="2" Grid.Row="0">
                     <Button Content="Smazat pravidlo" Width="120" Margin="10,0"/>
                     <Button Content="Zkopírovat pravidlo" Width="120" Margin="10,0"/>
                     <Button Content="Přidat pravidlo" Width="120" Margin="10,0"/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" 
+                            HorizontalAlignment="Right" 
+                            Grid.Column="1" 
+                            Grid.ColumnSpan="2" 
+                            Grid.Row="1"
+                            Margin="0,20,0,0">
+                    <TextBlock Text="Poznámka" Margin="0,0,10,0"/>
+                    <TextBox x:Name="Poznamka" Width="590" IsReadOnly="True" Background="WhiteSmoke" FontSize="14"/>
                 </StackPanel>
             </Grid>
         </Border>
@@ -71,10 +94,30 @@
                     <StackPanel Grid.Column="3" Margin="10,10,10,21">
                         <StackPanel Orientation="Vertical" Margin="0,0,0,10">
                             <TextBlock Text="After select"/>
-                            <TextBox Height="100" Margin="0,10,0,0"/>
+                            <avalonEdit:TextEditor
+                                xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"  
+                                Name="AfterSelectAvalon"
+                                Height="100"
+                                FontFamily="Consolas"
+                                FontSize="10pt" 
+                                WordWrap="True"
+                                ShowLineNumbers="true" 
+                                LineNumbersForeground="#FF2B91AF"
+                                HorizontalScrollBarVisibility="Hidden"
+                                VerticalScrollBarVisibility="Hidden" />
                             <!-- Adjust height as needed -->
                             <TextBlock Margin="0,10,0,5" Text="Soupisla select"/>
-                            <TextBox Height="100" Margin="0,10,0,0"/>
+                            <avalonEdit:TextEditor
+                                xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"  
+                                Name="SoupislaSelectAvalon"
+                                Height="100"
+                                FontFamily="Consolas"
+                                FontSize="10pt" 
+                                WordWrap="True"
+                                ShowLineNumbers="true" 
+                                LineNumbersForeground="#FF2B91AF"
+                                HorizontalScrollBarVisibility="Hidden"
+                                VerticalScrollBarVisibility="Hidden" />
                             <!-- Adjust height as needed -->
                         </StackPanel>
 
@@ -120,7 +163,7 @@
                     </StackPanel>
 
                     <!-- Tab Control for 'V1' -->
-                    <TabControl Grid.Row="2" Grid.Column="1" Name="VariantsTabControl" Margin="0,10,0,0">
+                    <TabControl Grid.Row="2" Name="VariantsTabControl" Margin="248,10,0,0" Grid.ColumnSpan="2">
                         <TabItem Header="V1">
                             <Grid Margin="0,10,0,0">
                                 <Grid.RowDefinitions>
@@ -153,7 +196,7 @@
                     </TabControl>
                 </Grid>
             </TabItem>
-            <TabItem Header="Email" Height="20" VerticalAlignment="Top">
+            <TabItem Header="Email">
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
@@ -206,6 +249,7 @@
                                     <Label Content="Port" VerticalAlignment="Center"/>
                                     <TextBox Name="Port" Width="50" VerticalAlignment="Center" Margin="5,0,0,0"/>
                                     <CheckBox Name="UseSSL" Content="SSL" Margin="20,0,0,0" VerticalAlignment="Center"/>
+                                    <Button Content="Test Email" Width="70" Margin="15,0,0,0" />
                                 </StackPanel>
                             </Grid>
                         </StackPanel>
@@ -218,65 +262,80 @@
                     </StackPanel>
 
                     <!-- Right column for email variants -->
-                    <StackPanel Grid.Column="1" Margin="10">
+                    <Grid Grid.Column="1" Margin="10">
+                        <!-- Define RowDefinitions for spacing -->
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
                         <!-- Buttons above the TabControl -->
-                        <StackPanel Orientation="Horizontal" Margin="0,10">
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,10">
                             <Button Content="Přidat variantu" Width="120" Margin="10,0,10,0" />
                             <Button Content="Zkopírovat variantu" Width="120" Margin="0,0,10,0"/>
                             <Button Content="Odebrat variantu" Width="120" />
                         </StackPanel>
 
                         <!-- TabControl for email variants -->
-                        <TabControl Margin="0,10,0,0" RenderTransformOrigin="0.5,0.5">
-                            <TabControl.RenderTransform>
-                                <TransformGroup>
-                                    <ScaleTransform/>
-                                    <SkewTransform AngleX="-0.723"/>
-                                    <RotateTransform/>
-                                    <TranslateTransform X="-1.487"/>
-                                </TransformGroup>
-                            </TabControl.RenderTransform>
+                        <TabControl Grid.Row="1" Margin="2,5,1,5" RenderTransformOrigin="0.5,0.5">
+
                             <TabItem Header="V1">
                                 <Grid Margin="10,0,10,0">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="54*"/>
-                                        <RowDefinition Height="55*"/>
-                                        <RowDefinition Height="113*"/>
+                                        <RowDefinition Height="*"/>
+                                        <RowDefinition Height="*"/>
+                                        <RowDefinition Height="Auto"/>
                                         <!-- This will allow the email text to expand -->
-                                        <RowDefinition Height="Auto" MinHeight="45.96"/>
+                                        <RowDefinition Height="*" MinHeight="45.96"/>
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="2*"/>
                                     </Grid.ColumnDefinitions>
 
                                     <!-- Variant Name and Condition on the same row -->
-                                    <Label Content="Název varianty" Grid.Column="0" VerticalAlignment="Center" Grid.ColumnSpan="2" Height="26" Margin="0,0,209,0"/>
-                                    <TextBox Name="VariantName" Grid.Column="1" VerticalAlignment="Center" Grid.ColumnSpan="2" Height="18" Margin="0,0,107,0"/>
-                                    <Label Content="Podmínka varianty" Grid.Column="2" VerticalAlignment="Center" Height="26"/>
-                                    <TextBox Name="VariantCondition" Grid.Column="2" VerticalAlignment="Center" Grid.ColumnSpan="2" Height="18" Margin="107,0,0,0"/>
+                                    <Label Content="Název varianty" Grid.Column="0" Margin="0,0,2,18" Grid.RowSpan="2"/>
+                                    <TextBox Name="VariantName" Grid.Column="1" Margin="0,4,5,29" Grid.RowSpan="2"/>
+                                    <Label Content="Podmínka varianty" Grid.Column="2" Margin="0,-1,149,21" Grid.RowSpan="2" Grid.ColumnSpan="2" VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch"/>
+                                    <TextBox Name="VariantCondition" Grid.Column="3" Margin="112,4,0,29" Grid.RowSpan="2"/>
 
                                     <!-- Email Recipient -->
-                                    <Label Content="Email příjemce" Grid.Row="1" Grid.Column="0" Margin="0,0,10,0" VerticalAlignment="Center" Height="26"/>
-                                    <TextBox Name="EmailRecipient" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Height="18"/>
+                                    <Label Content="Email příjemce" Grid.Row="1" Grid.Column="0" Margin="0,4,10,16" Grid.RowSpan="2"/>
+                                    <TextBox Name="EmailRecipient" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" Margin="0,8,0,3"/>
 
                                     <!-- Email Subject -->
-                                    <Label Content="Předmět emailu" Grid.Row="2" Grid.Column="0" Margin="0,0,10,0" VerticalAlignment="Center" Height="26"/>
-                                    <TextBox Name="EmailSubject" Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Height="18"/>
+                                    <Label Content="Předmět emailu" Grid.Row="2" Grid.Column="0" Margin="0,4,10,16"/>
+                                    <TextBox Name="EmailSubject" Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" Margin="0,6,0,16"/>
 
                                     <!-- Email Text -->
-                                    <Label Content="Text emailu" Grid.Row="4" Grid.Column="0" Margin="0,44,10,0" VerticalAlignment="Top" Height="26" Grid.RowSpan="2"/>
-                                    <TextBox Name="EmailText" Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" Margin="0,5,0,5" TextWrapping="Wrap" 
-                     VerticalScrollBarVisibility="Auto" Grid.IsSharedSizeScope="True" Grid.RowSpan="3"/>
+                                    <Label Content="Text emailu" 
+                                           Grid.Row="3" 
+                                           Grid.RowSpan="3"
+                                           Grid.Column="0" 
+                                           VerticalContentAlignment="Center"/>
+                                    <TextBox Name="EmailText"
+                                             MinHeight="10"
+                                             Grid.Row="3" 
+                                             Grid.RowSpan="4"
+                                             Grid.Column="1" 
+                                             Grid.ColumnSpan="3"
+                                             Margin="0,0,0,63" 
+                                             TextWrapping="Wrap" 
+                                             VerticalScrollBarVisibility="Auto" 
+                                             Grid.IsSharedSizeScope="True"/>
 
                                     <!-- Sestavy Section -->
-                                    <Grid Grid.Row="6" Grid.ColumnSpan="4" Margin="0,10,0,10">
+                                    <Grid Grid.Row="6" Grid.ColumnSpan="4" Margin="0,0,0,5" VerticalAlignment="Bottom">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition/>
+                                        </Grid.RowDefinitions>
                                         <!-- Define the columns inside the nested Grid for Sestavy section -->
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto"/>
@@ -287,7 +346,7 @@
                                             <ColumnDefinition Width="*"/>
                                             <ColumnDefinition Width="Auto"/>
                                         </Grid.ColumnDefinitions>
-                                        <StackPanel Orientation="Horizontal">
+                                        <StackPanel Orientation="Horizontal" Margin="0,2,0,2" Grid.ColumnSpan="6" Grid.RowSpan="2">
                                             <Label Content="Sestavy" Grid.Column="0" Margin="5,0,0,0" VerticalAlignment="Center"/>
                                             <Label Content="ID Sestavy:" Grid.Column="1" Margin="45,0,0,0" VerticalAlignment="Center"/>
                                             <TextBox Name="ReportID" Grid.Column="2" Margin="5,0,0,0" VerticalAlignment="Center" MinWidth="120"/>
@@ -298,7 +357,7 @@
                                     </Grid>
 
                                     <!-- Last Row -->
-                                    <StackPanel Grid.Row="7" Grid.ColumnSpan="4" Orientation="Horizontal" Margin="0,10,0,10">
+                                    <StackPanel Grid.Row="7" Grid.ColumnSpan="4" Orientation="Horizontal" Margin="0,15,0,15" VerticalAlignment="Bottom">
                                         <CheckBox Name="CreateListCheckBox" Content="Vytvořit soupisku" Margin="5,0,0,10" VerticalAlignment="Center"/>
                                         <CheckBox Name="SendListCheckBox" Content="Odeslat" Margin="5,0,0,10" VerticalAlignment="Center"/>
                                         <Label Content="Soupiska file:" Margin="5,0,0,10" VerticalAlignment="Center"/>
@@ -310,8 +369,7 @@
                             </TabItem>
                             <!-- Add more tabs as needed -->
                         </TabControl>
-
-                    </StackPanel>
+                    </Grid>
                 </Grid>
             </TabItem>
             <!-- Add more tabs as required -->


### PR DESCRIPTION
1)	Tab SQL Dotazy – textboxes “After Select” and “Soupiska Select” needs to be changed to avalonEdit control – the same way as it is for “podkladový select” control.

2)	EMAIL tab – design is incorrect. Tab with variats (V1) is not having responsive design  - when form is resized tab control stay in same size and there is unused space – marked Expected behaviour is that variant tab control will be resized together with form (the same way as it is already done for tab SMS) Email textbox should be resized together with tab and use the empty space. Other textboxes should stay 1 line only but resizable to wide.

3)	Form header – in header there is missing one row with rulename and note. We need to add it to match design on screens below.